### PR TITLE
bug fixed in metrics (prometheus)

### DIFF
--- a/week07_application_deployment/04_metrics/prom/prometheus.yml
+++ b/week07_application_deployment/04_metrics/prom/prometheus.yml
@@ -18,7 +18,7 @@ scrape_configs:
   - job_name: 'app-server'
     scrape_interval: 5s
     static_configs:
-      - targets: [ 'app:80' ]
+      - targets: [ 'app:8080' ]
 
   - job_name: 'nginx'
     scrape_interval: 5s


### PR DESCRIPTION
Порт сервера в конфиге prometheus указан старый (80, а не 8080), из-за чего метрики в localhost:8080/metrics выводятся текстом, но в prometheus/grafana не доходят. @ADKosm